### PR TITLE
Externalize OPENAPI_API_KEY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# credentials
+OPENAI_API_KEY.js

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ The current few-shot prompt guides GPT-3 in accurately understanding the JSON fo
 ## Setup
 
 1. Run `npm install` to download required dependencies (currently just [react-graph-vis](https://github.com/crubier/react-graph-vis)).
-2. Enter your OPENAI_API_KEY in `src/App.js`.
+2. CREATE `src/OPENAI_API_KEY.js` using template in `src/OPENAI_API_KEY.template.js`.
 3. Run `npm run start`. GraphGPT should open up in a new browser tab.

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import './App.css';
 import Graph from "react-graph-vis";
 import React, { useState } from "react";
 
-const OPENAI_API_KEY = "YOUR OPENAI API KEY";
+import OPENAI_API_KEY from "./OPENAI_API_KEY.js";
 
 const DEFAULT_PARAMS = {
   "model": "text-davinci-003",

--- a/src/OPENAI_API_KEY.template.js
+++ b/src/OPENAI_API_KEY.template.js
@@ -1,0 +1,3 @@
+const OPENAI_API_KEY =
+  "<GET KEY FROM https://platform.openai.com/account/api-keys>";
+export default OPENAI_API_KEY;


### PR DESCRIPTION
Allows .gitignore to ignore API Key
Prevents accidental upload of credentials