### PR TITLE
prompt() for API key and store in localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,11 @@ import './App.css';
 import Graph from "react-graph-vis";
 import React, { useState } from "react";
 
-const OPENAI_API_KEY = "YOUR OPENAI API KEY";
+if (!localStorage.getItem("OPENAI_API_KEY")) {
+  localStorage.setItem("OPENAI_API_KEY", prompt("Enter your OpenAI API key"));
+}
+
+const OPENAI_API_KEY = localStorage.getItem("OPENAI_API_KEY");
 
 const DEFAULT_PARAMS = {
   "model": "text-davinci-003",


### PR DESCRIPTION
Add a prompt that asks for the OpenAI API key and stores it in localStorage.

I suggest not merging this as is! I think the UI can definitely be improved--

Consider making these changes before merging:
- Don't ask for the API key before showing any info. Instead, add a button or field (`type=password`) to set the API key.
- Add a link to this repo.

Some related and easy features that I also think should be added, but perhaps can go in another PR:
- Save state to localStorage too.
- Add way to import and export the state. The easiest way would be a textarea under the graph showing the state. (I think showing the state can be useful to help user understanding anyway.)